### PR TITLE
Build: Makefile: do not pass BUILD_KEYS in release build

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -215,13 +215,13 @@ ifeq ($(TARGET_BUILD_VARIANT),user)
 
   # Dev. branches should have DISPLAY_BUILD_NUMBER set
   ifeq (true,$(DISPLAY_BUILD_NUMBER))
-    BUILD_DISPLAY_ID := $(BUILD_ID).$(BUILD_NUMBER_FROM_FILE) $(BUILD_KEYS)
+    BUILD_DISPLAY_ID := $(BUILD_ID).$(BUILD_NUMBER)
   else
-    BUILD_DISPLAY_ID := $(BUILD_ID) $(BUILD_KEYS)
+    BUILD_DISPLAY_ID := $(BUILD_ID)
   endif
 else
   # Non-user builds should show detailed build information
-  BUILD_DISPLAY_ID := $(build_desc)
+  BUILD_DISPLAY_ID := $(BUILD_ID).$(BUILD_NUMBER).$(TARGET_BUILD_VARIANT)
 endif
 
 # Accepts a whitespace separated list of product locales such as


### PR DESCRIPTION
Also replace build_desc with build ID in eng/userdebug build.

Starting with Oreo, individual builds are identified with a new build ID format, in the form of PVBB.YYMMDD.HHMMSS
The P part represents the first letter of the code name of the platform release, e.g. O is Oreo.
The V part represents a supported vertical. By convention, P represents the primary platform branch.
The BB part represents a alpha numeric code which allows Google to identify the exact code branch that the build was made from.
The YYMMDD part identifies the exact date at which a build was made.
The HHMMSS part identifies the exact time at which a build was made.