### PR TITLE
Build: Makefile: copy u-boot bootloader to RADIO dir for OTA

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -2473,6 +2473,10 @@ endif # BOARD_USES_RECOVERY_AS_BOOT
 ifdef BOARD_KERNEL_DTS
 	$(hide) echo "$(BOARD_KERNEL_DTS)" > $(zip_root)/BOOT/dtb
 endif
+ifdef DTS_PLATFORM
+	$(hide) mkdir -p $(zip_root)/RADIO;
+	$(hide) $(ACP) $(PRODUCT_OUT)/u-boot-$(DTS_PLATFORM).imx $(zip_root)/RADIO/bootloader.img
+endif
 	$(hide) $(foreach t,$(INSTALLED_RADIOIMAGE_TARGET),\
 	            mkdir -p $(zip_root)/RADIO; \
 	            cp $(t) $(zip_root)/RADIO/$(notdir $(t));)


### PR DESCRIPTION
Copy bootloader.img image to obj out dir for OTA script can handle it.
Must have for bootloader OTA update while migrating to Oreo via OTA,
because new u-boot arguments can not be passed via misc partition.