### PR TITLE
Include flattened device tree into recovery image

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -2441,6 +2441,9 @@ endif
 ifdef BOARD_KERNEL_PAGESIZE
 	$(hide) echo "$(BOARD_KERNEL_PAGESIZE)" > $(zip_root)/$(PRIVATE_RECOVERY_OUT)/pagesize
 endif
+ifdef BOARD_KERNEL_DTS
+	$(hide) echo "$(BOARD_KERNEL_DTS)" > $(zip_root)/$(PRIVATE_RECOVERY_OUT)/dtb
+endif
 endif # INSTALLED_RECOVERYIMAGE_TARGET defined or BOARD_USES_RECOVERY_AS_BOOT is true
 	@# Components of the boot image
 	$(hide) mkdir -p $(zip_root)/BOOT


### PR DESCRIPTION
releasetools don't use any of already built images to include them
into result package. Instead of this, all images are built from
scratch, using data placed into "dist files out folder".
Recovery image in not an exception, so it have build too.
Due to reasons unknown to me, source files for recovery image miss
flattened device tree, as result this image unable to boot.

This change adds flattened device tree to recovery image source
files in silmilar way like it done for boot image.