### PR TITLE
remove camera-related packages

### DIFF
--- a/target/product/base.mk
+++ b/target/product/base.mk
@@ -32,7 +32,6 @@ PRODUCT_PACKAGES += \
     bmgr \
     bugreport \
     bugreportz \
-    cameraserver \
     content \
     dnsmasq \
     dpm \
@@ -54,9 +53,6 @@ PRODUCT_PACKAGES += \
     libaudiopolicyservice \
     libaudiopolicymanager \
     libbundlewrapper \
-    libcamera_client \
-    libcameraservice \
-    libcamera2ndk \
     libdl \
     libdrmclearkeyplugin \
     libclearkeycasplugin \

--- a/target/product/generic_no_telephony.mk
+++ b/target/product/generic_no_telephony.mk
@@ -20,7 +20,6 @@
 PRODUCT_PACKAGES := \
     Bluetooth \
     BluetoothMidiService \
-    Camera2 \
     Gallery2 \
     Music \
     MusicFX \
@@ -37,14 +36,6 @@ PRODUCT_PACKAGES += \
     clatd.conf \
     pppd \
     screenrecord
-
-PRODUCT_PACKAGES += \
-    librs_jni \
-    libvideoeditor_jni \
-    libvideoeditor_core \
-    libvideoeditor_osal \
-    libvideoeditor_videofilters \
-    libvideoeditorplayer \
 
 PRODUCT_PACKAGES += \
     audio.primary.default \

--- a/target/product/treble_common.mk
+++ b/target/product/treble_common.mk
@@ -39,11 +39,6 @@ PRODUCT_PACKAGES := \
     android.hardware.boot@1.0 \
     android.hardware.broadcastradio@1.0 \
     android.hardware.broadcastradio@1.1 \
-    android.hardware.camera.common@1.0 \
-    android.hardware.camera.device@1.0 \
-    android.hardware.camera.device@3.2 \
-    android.hardware.camera.metadata@3.2 \
-    android.hardware.camera.provider@2.4 \
     android.hardware.configstore-utils \
     android.hardware.configstore@1.0 \
     android.hardware.contexthub@1.0 \
@@ -100,7 +95,6 @@ PRODUCT_PACKAGES += \
     libaudioroute \
     libaudioutils \
     libbinder \
-    libcamera_metadata \
     libcap \
     libcrypto \
     libcrypto_utils \


### PR DESCRIPTION
removed a lot of camera-related packages:
- Camera2 app
- video editor libraries
- camera HAL libraries
- camera service binary

Note: despite on `libcamera_metadata` and `libcamera_client` , they are implicitly built... A lot of stuff requires `libcamera_metadata` (sources in system/media/camera) library, even not camera-related. `libcamera_client` (sources in frameworks/av/camera) is required for a few libraries from frameworks/base and frameworks/av contain "media" in own names, but it can't be (at least easily removed) because it used by MediaRecorder class, which one is used in MediaPlayerService interface. This is used at least in camera effects (and something related) implementation (frameworks/base/media/mca), I tried to drop them, but got compilation error complaining about Android API changes (that I changed something in previously released Android API).
so, that 2 camera libraries will stay