### PR TITLE
Re-enable SystemUI

### DIFF
--- a/target/product/generic_no_telephony.mk
+++ b/target/product/generic_no_telephony.mk
@@ -21,6 +21,9 @@ PRODUCT_PACKAGES := \
     Bluetooth \
     BluetoothMidiService \
     OneTimeInitializer \
+    Provision \
+    SystemUI \
+    SysuiDarkThemeOverlay \
     WallpaperCropper
 
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Provision package is vital for a lot of UI features, app switcher
is one of them, this doesn't work without it.
Quick Settings also is not shown without this package.

This commit completely reverts 9bb002c6430d17f24355c63cc47dbb9bbb0a025e
and partially reverts d2c85a32c97834ba469ea30497427ff1ae4fa96a