### PR TITLE
Re-enable DocumentsUI

### DIFF
--- a/target/product/core.mk
+++ b/target/product/core.mk
@@ -24,6 +24,7 @@ PRODUCT_PACKAGES += \
     BuiltInPrintService \
     CaptivePortalLogin \
     CertInstaller \
+    DocumentsUI \
     ExternalStorageProvider \
     FusedLocation \
     InputDevices \


### PR DESCRIPTION
DocumentsUI is simple file manager used to explore external drives
in various cases, for certificates installation for example.