### PR TITLE
Build: make: update Android security patch level to June 2019

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -186,7 +186,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2017-11-05
+      PLATFORM_SECURITY_PATCH := 2019-06-05
 endif
 
 ifndef PLATFORM_BASE_OS


### PR DESCRIPTION
To show correct version under the Settings -> About tablet menu.
Actual Android security patch level is June 5, 2019.